### PR TITLE
modified regex begin/end to ignore escaped forward slash

### DIFF
--- a/yara.tmLanguage
+++ b/yara.tmLanguage
@@ -104,7 +104,7 @@
 		</dict>
 		<dict>
 			<key>begin</key>
-			<string>/</string>
+			<string>(\s|=)/</string>
 			<key>beginCaptures</key>
 			<dict>
 				<key>0</key>
@@ -114,7 +114,7 @@
 				</dict>
 			</dict>
 			<key>end</key>
-			<string>/</string>
+			<string>/$</string>
 			<key>endCaptures</key>
 			<dict>
 				<key>0</key>


### PR DESCRIPTION
Found that escaped forward slashes were being treated as the beginning or ending of a regular expression. Modified the begin string to '(=|\s)/' and the end to '/$'
